### PR TITLE
Small improvements to the UIAutomation sample

### DIFF
--- a/uiautomation/bindings/build.rs
+++ b/uiautomation/bindings/build.rs
@@ -5,7 +5,5 @@ fn main() {
         Windows::Win32::System::SystemServices::*,
         Windows::Win32::UI::WindowsAndMessaging::*,
         Windows::UI::UIAutomation::AutomationElement,
-        Windows::Win32::System::SystemInformation::OSVERSIONINFOW,
-        Windows::Win32::Foundation::NTSTATUS,
     );
 }

--- a/uiautomation/bindings/build.rs
+++ b/uiautomation/bindings/build.rs
@@ -5,5 +5,7 @@ fn main() {
         Windows::Win32::System::SystemServices::*,
         Windows::Win32::UI::WindowsAndMessaging::*,
         Windows::UI::UIAutomation::AutomationElement,
+        Windows::Win32::System::SystemInformation::OSVERSIONINFOW,
+        Windows::Win32::Foundation::NTSTATUS,
     );
 }

--- a/uiautomation/src/main.rs
+++ b/uiautomation/src/main.rs
@@ -4,24 +4,15 @@ use Windows::Win32::System::Com::*;
 use Windows::Win32::UI::Accessibility::*;
 use Windows::Win32::UI::WindowsAndMessaging::*;
 use Windows::UI::UIAutomation::*;
-use Windows::Win32::System::SystemInformation::OSVERSIONINFOW;
-use Windows::Win32::Foundation::NTSTATUS;
 
 fn main() -> Result<()> {
-    unsafe {  
-        let version_info = get_version_info();
-        if version_info?.dwMajorVersion < 11 {
-            println!("This sample is intended to run on Windows 11.");
-            panic!()
-        }
-        
+    unsafe {
         let window = FindWindowA(None, "Calculator");
-        if window.is_null() 
-        {
+        if window.is_null() {
             println!("Calculator window not found. Please run calc.exe.");
             panic!()
         }
-        
+
         CoInitializeEx(std::ptr::null_mut(), COINIT_MULTITHREADED)?;
 
         // Start with COM API
@@ -32,32 +23,12 @@ fn main() -> Result<()> {
         let name = element.get_CurrentName()?;
         println!("window name: {}", name);
 
-        // Query for WinRT API 
-        let element: AutomationElement = element.cast()?;
+        // Query for WinRT API (will fail on earlier versions of Windows)
+        let element2: AutomationElement = element.cast()?;
 
         // Use WinRT API
-        println!("file name: {}", element.ExecutableFileName()?);
+        println!("file name: {}", element2.ExecutableFileName()?);
     }
 
     Ok(())
-}
-
-extern "system" {
-    fn RtlGetVersion(lpVersionInformation: *mut OSVERSIONINFOW) -> NTSTATUS;
-}
-
-fn get_version_info() -> Result<OSVERSIONINFOW>  {
-    unsafe {
-        let mut version_info = OSVERSIONINFOW {
-            dwOSVersionInfoSize: 0,
-            dwMajorVersion: 0,
-            dwMinorVersion: 0,
-            dwBuildNumber: 0,
-            dwPlatformId: 0,
-            szCSDVersion: [0; 128],
-        };
-
-        RtlGetVersion(&mut version_info);
-        return Ok(version_info)
-    }
 }

--- a/uiautomation/src/main.rs
+++ b/uiautomation/src/main.rs
@@ -4,11 +4,25 @@ use Windows::Win32::System::Com::*;
 use Windows::Win32::UI::Accessibility::*;
 use Windows::Win32::UI::WindowsAndMessaging::*;
 use Windows::UI::UIAutomation::*;
+use Windows::Win32::System::SystemInformation::OSVERSIONINFOW;
+use Windows::Win32::Foundation::NTSTATUS;
 
 fn main() -> Result<()> {
-    unsafe {
-        CoInitializeEx(std::ptr::null_mut(), COINIT_MULTITHREADED)?;
+    unsafe {  
+        let version_info = get_version_info();
+        if version_info?.dwMajorVersion < 11 {
+            println!("This sample is intended to run on Windows 11.");
+            panic!()
+        }
+        
         let window = FindWindowA(None, "Calculator");
+        if window.is_null() 
+        {
+            println!("Calculator window not found. Please run calc.exe.");
+            panic!()
+        }
+        
+        CoInitializeEx(std::ptr::null_mut(), COINIT_MULTITHREADED)?;
 
         // Start with COM API
         let automation: IUIAutomation = CoCreateInstance(&CUIAutomation, None, CLSCTX_ALL)?;
@@ -18,7 +32,7 @@ fn main() -> Result<()> {
         let name = element.get_CurrentName()?;
         println!("window name: {}", name);
 
-        // Query for WinRT API (will fail on earlier versions of Windows)
+        // Query for WinRT API 
         let element: AutomationElement = element.cast()?;
 
         // Use WinRT API
@@ -26,4 +40,24 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+extern "system" {
+    fn RtlGetVersion(lpVersionInformation: *mut OSVERSIONINFOW) -> NTSTATUS;
+}
+
+fn get_version_info() -> Result<OSVERSIONINFOW>  {
+    unsafe {
+        let mut version_info = OSVERSIONINFOW {
+            dwOSVersionInfoSize: 0,
+            dwMajorVersion: 0,
+            dwMinorVersion: 0,
+            dwBuildNumber: 0,
+            dwPlatformId: 0,
+            szCSDVersion: [0; 128],
+        };
+
+        RtlGetVersion(&mut version_info);
+        return Ok(version_info)
+    }
 }


### PR DESCRIPTION
When running the UIAutomation sample on my Windows 10 box I received the following error:

- `0x80040201: An event was unable to invoke any of the subscribers`

This error was likely `UIA_E_ELEMENTNOTAVAILABLE` and due to the fact `window` was null. After running `calc.exe` the error disappeared. 

After running the Calculator application the follow error message was shown:

- `0x80004002: No such interface supported`

Although the `readme.md` clearly states that Windows 11 is needed, I thought this sample could be improved with runtime checks.

 I understand that this sample is targeted to the UIAutomation functionality and that samples generally need to be as simple as possible, however I felt these checks were trivial to implement and are an improvement over the `readme.md`.
