### PR TITLE
Fix RSS sample

### DIFF
--- a/rss/Cargo.toml
+++ b/rss/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2018"
 [dependencies.windows]
 version = "0.29"
 features = [
-    "alloc",
-    "std",
+    "Foundation",
     "Foundation_Collections",
     "Web_Syndication",
 ]

--- a/rss/src/main.rs
+++ b/rss/src/main.rs
@@ -1,10 +1,27 @@
-use windows::{Foundation::Uri, Web::Syndication::SyndicationClient};
+use std::sync::mpsc;
+use windows::{
+    core::HSTRING,
+    Foundation::{AsyncOperationWithProgressCompletedHandler, Uri},
+    Web::Syndication::SyndicationClient,
+};
 
 fn main() -> windows::core::Result<()> {
-    let uri = Uri::CreateUri("https://kennykerr.ca/feed")?;
+    let uri = Uri::CreateUri(HSTRING::from("https://kennykerr.ca/feed"))?;
     let client = SyndicationClient::new()?;
-    let feed = client.RetrieveFeedAsync(uri)?.get()?;
 
+    let (sender, receiver) = mpsc::channel();
+    client.RetrieveFeedAsync(uri)?.SetCompleted(
+        AsyncOperationWithProgressCompletedHandler::new(move |op, _status| {
+            if let Some(op) = op {
+                sender
+                    .send(op.GetResults()?)
+                    .expect("send over mpsc channel");
+            }
+            Ok(())
+        }),
+    )?;
+
+    let feed = receiver.recv().unwrap();
     for item in feed.Items()? {
         println!("{}", item.Title()?.Text()?);
     }


### PR DESCRIPTION
Today I wanted to try out somethings with RSS feeds, so I was happy to see that there is a sample about RSS feeds. Unfortunately, this sample doesn't compile. After some looking around at some of the other samples which use `Async` methods, this is the solution I came up with, so I thought I'd see if you guys are interested in merging this.

P.S. The [RSS reader tutorial](https://docs.microsoft.com/en-us/windows/dev-environment/rust/rss-reader-rust-for-windows) (which is one of the first search results when searching for `rust windows rss feed reader`) seems to be even more out dated than the sample in this repo, as it uses version `0.9.1` of the `windows` crate, which still uses the bindings library approach instead of the feature flags approach which is currently recommended.